### PR TITLE
Feature/get chat

### DIFF
--- a/schnauzer/src/app.ts
+++ b/schnauzer/src/app.ts
@@ -3,6 +3,7 @@ import * as express from "express";
 import { Application, NextFunction, Request, Response } from "express";
 import router from "./routes";
 import { HttpError } from "./error";
+import { errorHandler } from "./middleware/errorHandler";
 
 class App {
   private readonly app: Application;
@@ -18,14 +19,7 @@ class App {
       next(new HttpError("Not Found", 404));
     });
 
-    this.app.use(
-      (err: HttpError, req: Request, res: Response, next: NextFunction) => {
-        res.status(err.status || 500).json({
-          message: err.message,
-          status: err.status,
-        });
-      }
-    );
+    this.app.use(errorHandler);
   }
 
   public listen(port: number) {

--- a/schnauzer/src/app.ts
+++ b/schnauzer/src/app.ts
@@ -1,6 +1,8 @@
 import "reflect-metadata";
 import * as express from "express";
-import { Application } from "express";
+import { Application, NextFunction, Request, Response } from "express";
+import router from "./routes";
+import { HttpError } from "./error";
 
 class App {
   private readonly app: Application;
@@ -10,6 +12,20 @@ class App {
 
     this.app.use(express.json());
     this.app.use(express.urlencoded({ extended: false }));
+    this.app.use("/", router);
+
+    this.app.use((req: Request, res: Response, next: NextFunction) => {
+      next(new HttpError("Not Found", 404));
+    });
+
+    this.app.use(
+      (err: HttpError, req: Request, res: Response, next: NextFunction) => {
+        res.status(err.status || 500).json({
+          message: err.message,
+          status: err.status,
+        });
+      }
+    );
   }
 
   public listen(port: number) {

--- a/schnauzer/src/controller/chat.controller.ts
+++ b/schnauzer/src/controller/chat.controller.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction } from "express";
+import { HttpError } from "../error";
+import { Qna } from "../entity/qna";
+import { User } from "../entity/user";
+
+export class ChatController {
+  static getChats = async (req: Request, res: Response, next: NextFunction) => {
+    const { email }: { email: string } = res.locals.jwtPayload;
+    const userRepo = User.getRepository();
+    const qnaRepo = Qna.getRepository();
+    try {
+      if (await userRepo.findOne({ email })) {
+        const chats = await qnaRepo.find({ where: { user_email: email } });
+        res.status(200).json(chats);
+      } else {
+        throw new HttpError("어드민 불허", 400);
+      }
+    } catch (e) {
+      next(e);
+    }
+  };
+}

--- a/schnauzer/src/controller/chat.controller.ts
+++ b/schnauzer/src/controller/chat.controller.ts
@@ -1,13 +1,16 @@
 import { Request, Response, NextFunction } from "express";
+import { createConnection, getConnection } from "typeorm";
 import { HttpError } from "../error";
 import { Qna } from "../entity/qna";
 import { User } from "../entity/user";
+import { dbOptions } from "../config";
 
 export class ChatController {
   static getChats = async (req: Request, res: Response, next: NextFunction) => {
+    const connection = getConnection(dbOptions.CONNECTION_NAME);
     const { email }: { email: string } = res.locals.jwtPayload;
-    const userRepo = User.getRepository();
-    const qnaRepo = Qna.getRepository();
+    const userRepo = connection.getRepository(User);
+    const qnaRepo = connection.getRepository(Qna);
     try {
       if (await userRepo.findOne({ email })) {
         const chats = await qnaRepo.find({ where: { user_email: email } });

--- a/schnauzer/src/error.ts
+++ b/schnauzer/src/error.ts
@@ -1,0 +1,5 @@
+export class HttpError extends Error {
+  constructor(message: string, public status: number) {
+    super(message);
+  }
+}

--- a/schnauzer/src/middleware/errorHandler.ts
+++ b/schnauzer/src/middleware/errorHandler.ts
@@ -1,0 +1,14 @@
+import { ErrorRequestHandler } from "express";
+import { HttpError } from "../error";
+
+export const errorHandler: ErrorRequestHandler = (
+  err: HttpError,
+  req,
+  res,
+  next
+) => {
+  res.status(err.status || 500).json({
+    message: err.message,
+    status: err.status,
+  });
+};


### PR DESCRIPTION
# 채팅 목록 불러오는 controller 구현
## 목적
### 요약
채팅 목록을 불러오는 controller를 구현했습니다.
### 상세
1. jwt를 통해서 얻은 email 값으로 user가 존재하는지 확인
2. 존재하면 해당 email 값으로 채팅 목록을 찾아서 전송
3. 존재하지 않으면 400 에러 발생
## 영향을 미치는 부분
테스트 코드
## 참조(선택)
연관된 이슈 번호들
