### PR TITLE
Feature/get chats email

### DIFF
--- a/schnauzer/src/controller/chat.controller.ts
+++ b/schnauzer/src/controller/chat.controller.ts
@@ -40,7 +40,6 @@ export class ChatController {
       const chats = await Qna.findByUserEmailWithPage(userEmail, Number(page));
       res.status(200).json(chats);
     } catch (e) {
-      console.log(e);
       next(e);
     }
   };

--- a/schnauzer/src/controller/chat.controller.ts
+++ b/schnauzer/src/controller/chat.controller.ts
@@ -10,13 +10,18 @@ export class ChatController {
   static getChats = async (req: Request, res: Response, next: NextFunction) => {
     const userEmail = res.locals.jwtPayload.sub;
     const { page } = req.query;
+    const limit = 10;
     try {
       const connection = getConnection(dbOptions.CONNECTION_NAME);
       const userRepo = connection.getRepository(User);
       if (!(await userRepo.findOne({ email: userEmail }))) {
-        throw new HttpError("어드민 불허", 400);
+        throw new HttpError("알 수 없는 사용자", 400);
       }
-      const chats = await Qna.findByUserEmailWithPage(userEmail, Number(page));
+      const chats = await Qna.findByUserEmailWithPage(
+        userEmail,
+        Number(page),
+        limit
+      );
       res.status(200).json(chats);
     } catch (e) {
       next(e);
@@ -31,13 +36,18 @@ export class ChatController {
     const adminEmail = res.locals.jwtPayload.sub;
     const userEmail = req.params.email;
     const { page } = req.query;
+    const limit = 10;
     try {
       const connection = getConnection(dbOptions.CONNECTION_NAME);
       const adminRepo = connection.getRepository(Admin);
       if (!(await adminRepo.findOne({ email: adminEmail }))) {
-        throw new HttpError("일반 유저 불허", 400);
+        throw new HttpError("알 수 없는 사용자", 400);
       }
-      const chats = await Qna.findByUserEmailWithPage(userEmail, Number(page));
+      const chats = await Qna.findByUserEmailWithPage(
+        userEmail,
+        Number(page),
+        limit
+      );
       res.status(200).json(chats);
     } catch (e) {
       next(e);

--- a/schnauzer/src/controller/chat.controller.ts
+++ b/schnauzer/src/controller/chat.controller.ts
@@ -4,21 +4,43 @@ import { HttpError } from "../error";
 import { Qna } from "../entity/qna";
 import { User } from "../entity/user";
 import { dbOptions } from "../config";
+import { Admin } from "../entity/admin";
 
 export class ChatController {
   static getChats = async (req: Request, res: Response, next: NextFunction) => {
-    const { sub }: { sub: string } = res.locals.jwtPayload;
+    const userEmail = res.locals.jwtPayload.sub;
     const { page } = req.query;
-    const connection = getConnection(dbOptions.CONNECTION_NAME);
-    const userRepo = connection.getRepository(User);
     try {
-      if (await userRepo.findOne({ email: sub })) {
-        const chats = await Qna.findByUserEmailWithPage(sub, Number(page));
-        res.status(200).json(chats);
-      } else {
+      const connection = getConnection(dbOptions.CONNECTION_NAME);
+      const userRepo = connection.getRepository(User);
+      if (!(await userRepo.findOne({ email: userEmail }))) {
         throw new HttpError("어드민 불허", 400);
       }
+      const chats = await Qna.findByUserEmailWithPage(userEmail, Number(page));
+      res.status(200).json(chats);
     } catch (e) {
+      next(e);
+    }
+  };
+
+  static getChatsWithEmail = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    const adminEmail = res.locals.jwtPayload.sub;
+    const userEmail = req.params.email;
+    const { page } = req.query;
+    try {
+      const connection = getConnection(dbOptions.CONNECTION_NAME);
+      const adminRepo = connection.getRepository(Admin);
+      if (!(await adminRepo.findOne({ email: adminEmail }))) {
+        throw new HttpError("일반 유저 불허", 400);
+      }
+      const chats = await Qna.findByUserEmailWithPage(userEmail, Number(page));
+      res.status(200).json(chats);
+    } catch (e) {
+      console.log(e);
       next(e);
     }
   };

--- a/schnauzer/src/entity/qna.ts
+++ b/schnauzer/src/entity/qna.ts
@@ -46,10 +46,12 @@ export class Qna extends ValidationEntity {
 
   static findByUserEmailWithPage(email: string, page: number, limit: number) {
     return getConnection(dbOptions.CONNECTION_NAME)
-      .createQueryBuilder(Qna, "qna")
+      .createQueryBuilder()
+      .select("qna")
+      .from(Qna, "qna")
       .where("qna.user_email = :email", { email })
       .orderBy("created_at", "DESC")
-      .offset(page * 10)
+      .offset(page * limit)
       .limit(limit)
       .getMany();
   }

--- a/schnauzer/src/entity/qna.ts
+++ b/schnauzer/src/entity/qna.ts
@@ -44,13 +44,13 @@ export class Qna extends ValidationEntity {
   @CreateDateColumn()
   created_at: Date;
 
-  static findByUserEmailWithPage(email: string, page: number) {
+  static findByUserEmailWithPage(email: string, page: number, limit: number) {
     return getConnection(dbOptions.CONNECTION_NAME)
       .createQueryBuilder(Qna, "qna")
       .where("qna.user_email = :email", { email })
       .orderBy("created_at", "DESC")
       .offset(page * 10)
-      .limit(10)
+      .limit(limit)
       .getMany();
   }
 }

--- a/schnauzer/src/routes/index.ts
+++ b/schnauzer/src/routes/index.ts
@@ -5,5 +5,6 @@ import jwtCheck from "../middleware/jwtCheck";
 const router = Router();
 
 router.get("/chats", jwtCheck, ChatController.getChats);
+router.get("/chats/:email", jwtCheck, ChatController.getChatsWithEmail);
 
 export default router;

--- a/schnauzer/src/test/chat.test.ts
+++ b/schnauzer/src/test/chat.test.ts
@@ -147,7 +147,8 @@ describe("GET /schnauzer/chats/:email", () => {
       chai
         .request(server.application)
         .get("/schnauzer/chats/user1@example.com")
-        .set({ Authorization: validToken })
+        .set({ Authorization: adminEmailToken })
+        .query({ page: 0 })
         .end((err, res) => {
           res.should.have.status(200);
           res.body.should.be.a.instanceOf(Array);
@@ -156,5 +157,17 @@ describe("GET /schnauzer/chats/:email", () => {
         });
     });
   });
-  describe("fail", () => {});
+  describe("fail", () => {
+    it("should have status 400 with user token", (done) => {
+      chai
+        .request(server.application)
+        .get("/schnauzer/chats/user1@example.com")
+        .set({ Authorization: validToken })
+        .query({ page: 0 })
+        .end((err, res) => {
+          res.should.have.status(400);
+          done();
+        });
+    });
+  });
 });

--- a/schnauzer/src/test/data/chat.ts
+++ b/schnauzer/src/test/data/chat.ts
@@ -107,6 +107,6 @@ export const getLastChatsExpectedResult = [
   },
 ];
 
-export const getChatsWithEmailExpectedResult = chatExample.filter(
-  (v) => v.user_email === "user1@example.com"
-);
+export const getChatsWithEmailExpectedResult = chatExample
+  .filter((v) => v.user_email === "user1@example.com")
+  .reverse();


### PR DESCRIPTION
# get chats with user email 컨트롤러 구현
## 목적
### 요약
어드민이 유저들의 이메일로 채팅 목록 불러오는 컨트롤러 구현했습니다.
### 상세
1. Path parameter를 통해서 유저의 이메일을 받습니다.
2. Query를 통해서 page값을 받습니다.
3. 헤더로 어드민 토큰을 받습니다.
4. 해당 유저의 이메일과 페이지에 맞는 채팅 목록을 불러옵니다.
## 영향을 미치는 부분
테스트 코드와 라우터에 영향을 미쳤습니다.