### PR TITLE
Feature/get last chats

### DIFF
--- a/schnauzer/src/controller/chat.controller.ts
+++ b/schnauzer/src/controller/chat.controller.ts
@@ -68,14 +68,15 @@ export class ChatController {
         throw new HttpError("알 수 없는 사용자", 400);
       }
       let chats = await Qna.findLastChatOfEachUser();
-      const findUserPromises = chats.map(async (chat) => {
-        const user = await userRepo.findOne({ email: chat.user_email });
-        return {
-          ...chat,
-          user,
-        };
-      });
-      const lastChats = await Promise.all(findUserPromises);
+      const lastChats = await Promise.all(
+        chats.map(async (chat) => {
+          const user = await userRepo.findOne({ email: chat.user_email });
+          return {
+            ...chat,
+            user,
+          };
+        })
+      );
       res.status(200).json(lastChats);
     } catch (e) {
       next(e);

--- a/schnauzer/src/controller/chat.controller.ts
+++ b/schnauzer/src/controller/chat.controller.ts
@@ -53,4 +53,32 @@ export class ChatController {
       next(e);
     }
   };
+
+  static getLastChats = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    const adminEmail = res.locals.jwtPayload.sub;
+    try {
+      const connection = getConnection(dbOptions.CONNECTION_NAME);
+      const adminRepo = connection.getRepository(Admin);
+      const userRepo = connection.getRepository(User);
+      if (!(await adminRepo.findOne({ email: adminEmail }))) {
+        throw new HttpError("알 수 없는 사용자", 400);
+      }
+      let chats = await Qna.findLastChatOfEachUser();
+      const findUserPromises = chats.map(async (chat) => {
+        const user = await userRepo.findOne({ email: chat.user_email });
+        return {
+          ...chat,
+          user,
+        };
+      });
+      const lastChats = await Promise.all(findUserPromises);
+      res.status(200).json(lastChats);
+    } catch (e) {
+      next(e);
+    }
+  };
 }

--- a/schnauzer/src/entity/user.ts
+++ b/schnauzer/src/entity/user.ts
@@ -36,7 +36,7 @@ export class User extends ValidationEntity {
   @IsEmail()
   email: string;
 
-  @Column({ length: 100 })
+  @Column({ length: 100, select: false })
   @IsNotEmpty()
   password: string;
 
@@ -44,54 +44,54 @@ export class User extends ValidationEntity {
   @IsNotEmpty()
   receipt_number: number;
 
-  @Column({ type: "enum", enum: ApplyType, nullable: true })
+  @Column({ type: "enum", enum: ApplyType, nullable: true, select: false })
   apply_type: ApplyType;
 
-  @Column({ type: "enum", enum: AdditionalType, nullable: true })
+  @Column({ type: "enum", enum: AdditionalType, nullable: true, select: false })
   additional_type: AdditionalType;
 
-  @Column({ type: "enum", enum: GradeType, nullable: true })
+  @Column({ type: "enum", enum: GradeType, nullable: true, select: false })
   grade_type: GradeType;
 
-  @Column({ width: 2, nullable: true })
+  @Column({ width: 2, nullable: true, select: false })
   is_daejeon: boolean;
 
   @Column({ length: 15, nullable: true })
   name: string;
 
-  @Column({ type: "enum", enum: Sex, nullable: true })
+  @Column({ type: "enum", enum: Sex, nullable: true, select: false })
   sex: Sex;
 
-  @Column({ type: "date", nullable: true })
+  @Column({ type: "date", nullable: true, select: false })
   birth_date: Date;
 
-  @Column({ length: 15, nullable: true })
+  @Column({ length: 15, nullable: true, select: false })
   parent_name: string;
 
-  @Column({ length: 20, nullable: true })
+  @Column({ length: 20, nullable: true, select: false })
   parent_tel: string;
 
-  @Column({ length: 20, nullable: true })
+  @Column({ length: 20, nullable: true, select: false })
   applicant_tel: string;
 
-  @Column({ length: 500, nullable: true })
+  @Column({ length: 500, nullable: true, select: false })
   address: string;
 
-  @Column({ length: 5, nullable: true })
+  @Column({ length: 5, nullable: true, select: false })
   post_code: string;
 
-  @Column({ length: 45, nullable: true })
+  @Column({ length: 45, nullable: true, select: false })
   user_photo: string;
 
-  @Column({ length: 45, nullable: true })
+  @Column({ length: 45, nullable: true, select: false })
   home_tel: string;
 
-  @Column({ length: 1600, nullable: true })
+  @Column({ length: 1600, nullable: true, select: false })
   self_introduction: string;
 
-  @Column({ length: 1600, nullable: true })
+  @Column({ length: 1600, nullable: true, select: false })
   study_plan: string;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ select: false })
   created_at: Date;
 }

--- a/schnauzer/src/routes/index.ts
+++ b/schnauzer/src/routes/index.ts
@@ -6,5 +6,6 @@ const router = Router();
 
 router.get("/chats", jwtCheck, ChatController.getChats);
 router.get("/chats/:email", jwtCheck, ChatController.getChatsWithEmail);
+router.get("/last-chats", jwtCheck, ChatController.getLastChats);
 
 export default router;

--- a/schnauzer/src/test/chat.test.ts
+++ b/schnauzer/src/test/chat.test.ts
@@ -129,7 +129,7 @@ describe("GET /last-chats", () => {
       chai
         .request(server.application)
         .get("/schnauzer/last-chats")
-        .set({ Authorization: validToken })
+        .set({ Authorization: adminEmailToken })
         .end((err, res) => {
           res.should.have.status(200);
           res.body.should.be.a.instanceOf(Array);
@@ -138,7 +138,18 @@ describe("GET /last-chats", () => {
         });
     });
   });
-  describe("fail", () => {});
+  describe("fail", () => {
+    it("should have status 400 with user token", (done) => {
+      chai
+        .request(server.application)
+        .get("/schnauzer/last-chats")
+        .set({ Authorization: validToken })
+        .end((err, res) => {
+          res.should.have.status(400);
+          done();
+        });
+    });
+  });
 });
 
 describe("GET /schnauzer/chats/:email", () => {

--- a/schnauzer/src/test/data/chat.ts
+++ b/schnauzer/src/test/data/chat.ts
@@ -88,6 +88,11 @@ export const getLastChatsExpectedResult = [
     to: UserType.ADMIN,
     content: "감사합니다.",
     created_at: "2020-06-03T05:23:40.000Z",
+    user: {
+      email: "user3@example.com",
+      receipt_number: 12347,
+      name: "박예시",
+    },
   },
   {
     qna_id: 4,
@@ -96,6 +101,11 @@ export const getLastChatsExpectedResult = [
     to: UserType.ADMIN,
     content: "안녕하세요",
     created_at: "2020-06-03T05:16:40.000Z",
+    user: {
+      email: "user1@example.com",
+      receipt_number: 12345,
+      name: "김예시",
+    },
   },
   {
     qna_id: 2,
@@ -104,6 +114,11 @@ export const getLastChatsExpectedResult = [
     to: UserType.STUDENT,
     content: "반갑습니다",
     created_at: "2020-06-03T05:13:40.000Z",
+    user: {
+      email: "user2@example.com",
+      receipt_number: 12346,
+      name: "이예시",
+    },
   },
 ];
 

--- a/schnauzer/src/test/data/user.ts
+++ b/schnauzer/src/test/data/user.ts
@@ -3,15 +3,18 @@ export const users = [
     email: "user1@example.com",
     password: "examplepass",
     receipt_number: 12345,
+    name: "김예시",
   },
   {
     email: "user2@example.com",
     password: "examplepass",
     receipt_number: 12346,
+    name: "이예시",
   },
   {
     email: "user3@example.com",
     password: "examplepass",
     receipt_number: 12347,
+    name: "박예시",
   },
 ];


### PR DESCRIPTION
# get last chats 컨트롤러 구현
## 목적
### 요약
사용자들의 마지막 채팅 내역들을 불러오는 컨트롤러입니다.
### 상세
1. 서브쿼리와 IN을 사용해서 사용자 별 마지막 채팅 내역을 불러옵니다.
2. qna 엔티티의 user_email값을 이용해서 필요한 사용자 정보도 끼워 넣어 줍니다.
## 영향을 미치는 부분
라우터, 테스트 코드