### PR TITLE
Feature/patch is read

### DIFF
--- a/schnauzer/src/controller/chat.controller.ts
+++ b/schnauzer/src/controller/chat.controller.ts
@@ -112,4 +112,23 @@ export class ChatController {
       next(e);
     }
   };
+
+  static patchIsRead = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    const { userEmail } = req.body;
+    try {
+      await getConnection(dbOptions.CONNECTION_NAME)
+        .createQueryBuilder()
+        .update(Qna)
+        .set({ is_read: true })
+        .where("user_email = :userEmail", { userEmail })
+        .execute();
+      res.status(200).json();
+    } catch (e) {
+      next(e);
+    }
+  };
 }

--- a/schnauzer/src/routes/index.ts
+++ b/schnauzer/src/routes/index.ts
@@ -17,5 +17,6 @@ router.get("/last-chats", jwtCheck, isAdmin, ChatController.getLastChats);
 router.get("/search/:name", jwtCheck, isAdmin, SearchController.searchByName);
 router.post("/chat-user", jwtCheck, isUser, ChatController.postChatUser);
 router.post("/chat-admin", jwtCheck, isAdmin, ChatController.postChatAdmin);
+router.patch("/read-check", jwtCheck, isAdmin, ChatController.patchIsRead);
 
 export default router;

--- a/schnauzer/src/test/chat.test.ts
+++ b/schnauzer/src/test/chat.test.ts
@@ -18,6 +18,7 @@ import {
   getChatsExpectedResult2,
   postChatAdminResult,
   postChatUserResult,
+  patchIsReadResult,
 } from "./data/chat";
 import { users } from "./data/user";
 import { admins } from "./data/admin";
@@ -69,7 +70,9 @@ beforeEach((done) => {
     savePromises.push(qnaRepo.save(qnaRepo.create(chat)));
   });
   Promise.all(savePromises)
-    .then(() => done())
+    .then(() => {
+      done();
+    })
     .catch((err) => console.log(err));
 });
 
@@ -87,7 +90,7 @@ describe("GET /qna/chats", () => {
     it("should return expected object", (done) => {
       chai
         .request(server.application)
-        .get("/qna/chats")
+        .get("/v5/qna/chats")
         .set({ Authorization: validToken })
         .query({ page: 0 })
         .end((err, res) => {
@@ -100,7 +103,7 @@ describe("GET /qna/chats", () => {
     it("should return length-1 array", (done) => {
       chai
         .request(server.application)
-        .get("/qna/chats")
+        .get("/v5/qna/chats")
         .set({ Authorization: validToken })
         .query({ page: 1 })
         .end((err, res) => {
@@ -115,7 +118,7 @@ describe("GET /qna/chats", () => {
     it("should have status 401 with invalid token", (done) => {
       chai
         .request(server.application)
-        .get("/qna/chats")
+        .get("/v5/qna/chats")
         .set({ Authorization: invalidSecretToken })
         .end((err, res) => {
           res.should.have.status(401);
@@ -125,7 +128,7 @@ describe("GET /qna/chats", () => {
     it("should have status 409 with amdin email token", (done) => {
       chai
         .request(server.application)
-        .get("/qna/chats")
+        .get("/v5/qna/chats")
         .set({ Authorization: adminEmailToken })
         .query({ page: 0 })
         .end((err, res) => {
@@ -141,7 +144,7 @@ describe("GET /qna/last-chats", () => {
     it("should return expected object", (done) => {
       chai
         .request(server.application)
-        .get("/qna/last-chats")
+        .get("/v5/qna/last-chats")
         .set({ Authorization: adminEmailToken })
         .end((err, res) => {
           res.should.have.status(200);
@@ -155,7 +158,7 @@ describe("GET /qna/last-chats", () => {
     it("should have status 409 with user token", (done) => {
       chai
         .request(server.application)
-        .get("/qna/last-chats")
+        .get("/v5/qna/last-chats")
         .set({ Authorization: validToken })
         .end((err, res) => {
           res.should.have.status(409);
@@ -170,7 +173,7 @@ describe("GET /qna/chats/:email", () => {
     it("should return expected object", (done) => {
       chai
         .request(server.application)
-        .get("/qna/chats/user1@example.com")
+        .get("/v5/qna/chats/user1@example.com")
         .set({ Authorization: adminEmailToken })
         .query({ page: 0 })
         .end((err, res) => {
@@ -185,7 +188,7 @@ describe("GET /qna/chats/:email", () => {
     it("should have status 409 with user token", (done) => {
       chai
         .request(server.application)
-        .get("/qna/chats/user1@example.com")
+        .get("/v5/qna/chats/user1@example.com")
         .set({ Authorization: validToken })
         .query({ page: 0 })
         .end((err, res) => {
@@ -201,7 +204,7 @@ describe("GET /qna/search/:name", () => {
     it("should return expected object", (done) => {
       chai
         .request(server.application)
-        .get(`/qna/search/${encodeURI("예시")}`)
+        .get(`/v5/qna/search/${encodeURI("예시")}`)
         .set({ Authorization: adminEmailToken })
         .end((err, res) => {
           res.should.have.status(200);
@@ -213,7 +216,7 @@ describe("GET /qna/search/:name", () => {
     it("should return expected object", (done) => {
       chai
         .request(server.application)
-        .get(`/qna/search/${encodeURI("김예")}`)
+        .get(`/v5/qna/search/${encodeURI("김예")}`)
         .set({ Authorization: adminEmailToken })
         .end((err, res) => {
           res.should.have.status(200);
@@ -225,7 +228,7 @@ describe("GET /qna/search/:name", () => {
     it("should return empty array", (done) => {
       chai
         .request(server.application)
-        .get(`/qna/search/${encodeURI("노바디")}`)
+        .get(`/v5/qna/search/${encodeURI("노바디")}`)
         .set({ Authorization: adminEmailToken })
         .end((err, res) => {
           res.should.have.status(200);
@@ -239,7 +242,7 @@ describe("GET /qna/search/:name", () => {
     it("should have status 409 with user token", (done) => {
       chai
         .request(server.application)
-        .get(`/qna/search/${encodeURI("예시")}`)
+        .get(`/v5/qna/search/${encodeURI("예시")}`)
         .set({ Authorization: validToken })
         .query({ page: 0 })
         .end((err, res) => {
@@ -255,7 +258,7 @@ describe("POST /qna/chat-user", () => {
     it("should return expected object", (done) => {
       chai
         .request(server.application)
-        .post("/qna/chat-user")
+        .post("/v5/qna/chat-user")
         .set({ Authorization: validToken })
         .send({ content: "ㅎㅇ" })
         .end((err, res) => {
@@ -270,7 +273,7 @@ describe("POST /qna/chat-user", () => {
     it("should have status 409 with admin token", (done) => {
       chai
         .request(server.application)
-        .post("/qna/chat-user")
+        .post("/v5/qna/chat-user")
         .set({ Authorization: adminEmailToken })
         .send({ content: "ㅎㅇ" })
         .end((err, res) => {
@@ -281,7 +284,7 @@ describe("POST /qna/chat-user", () => {
     it("should have status 400 with wrong parameter", (done) => {
       chai
         .request(server.application)
-        .post("/qna/chat-user")
+        .post("/v5/qna/chat-user")
         .set({ Authorization: validToken })
         .send({ content: "" })
         .end((err, res) => {
@@ -297,7 +300,7 @@ describe("POST /qna/chat-admin", () => {
     it("should return expected object", (done) => {
       chai
         .request(server.application)
-        .post("/qna/chat-admin")
+        .post("/v5/qna/chat-admin")
         .set({ Authorization: adminEmailToken })
         .send({ content: "ㅎㅇ", userEmail: "user3@example.com" })
         .end((err, res) => {
@@ -312,7 +315,7 @@ describe("POST /qna/chat-admin", () => {
     it("should have status 409 with user token", (done) => {
       chai
         .request(server.application)
-        .post("/qna/chat-admin")
+        .post("/v5/qna/chat-admin")
         .set({ Authorization: validToken })
         .send({ content: "ㅎㅇ", userEmail: "user3@example.com" })
         .end((err, res) => {
@@ -323,11 +326,40 @@ describe("POST /qna/chat-admin", () => {
     it("should have status 400 with wrong parameter", (done) => {
       chai
         .request(server.application)
-        .post("/qna/chat-admin")
+        .post("/v5/qna/chat-admin")
         .set({ Authorization: adminEmailToken })
         .send({ content: "", userEmail: "user3@example.com" })
         .end((err, res) => {
           res.should.have.status(400);
+          done();
+        });
+    });
+  });
+});
+
+describe("PATCH /qna/read-check", () => {
+  describe("success", () => {
+    it("should change is_read to true", (done) => {
+      chai
+        .request(server.application)
+        .patch("/v5/qna/read-check")
+        .set({ Authorization: adminEmailToken })
+        .send({ userEmail: "user3@example.com" })
+        .end((err, res) => {
+          res.should.have.status(200);
+          done();
+        });
+    });
+  });
+  describe("fail", () => {
+    it("should have status 409 with user token", (done) => {
+      chai
+        .request(server.application)
+        .patch("/v5/qna/read-check")
+        .set({ Authorization: validToken })
+        .send({ userEmail: "user1@example.com" })
+        .end((err, res) => {
+          res.should.have.status(409);
           done();
         });
     });

--- a/schnauzer/src/test/data/chat.ts
+++ b/schnauzer/src/test/data/chat.ts
@@ -271,3 +271,11 @@ export const postChatAdminResult = {
   qna_id: 15,
   is_read: 0,
 };
+
+export const patchIsReadResult = chatExample.map((chat) => {
+  return {
+    ...chat,
+    created_at: new Date(chat.created_at),
+    is_read: chat.user_email === "user3@example.com" ? 1 : 0,
+  };
+});


### PR DESCRIPTION
# 채팅 읽음 API 구현
## 목적
### 요약
qna의 is_read column을 true로 바꾸는 API를 구현했습니다.
### 상세
어드민이 사용자의 채팅을 읽으면 사용자의 이메일을 통해서 qna의 is_read를 true로 업데이트합니다.
## 영향을 미치는 부분
## 참조(선택)
연관된 이슈 번호들
